### PR TITLE
Adds support for custom domain to bypass ad blockers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,20 @@ module.exports = {
   ]
 }
 ```
+
+### Bypass Ad Blockers
+
+You can also optionally specify a custom domain to bypass ad blockers. Read more about this in [our documentation](https://docs.simpleanalytics.com/bypass-ad-blockers).
+
+```js
+module.exports = {
+  plugins: [
+    {
+      use: 'gridsome-plugin-simple-analytics',
+      options: {
+        domain: 'api.example.com'
+      }
+    }
+  ]
+}
+```

--- a/gridsome.client.js
+++ b/gridsome.client.js
@@ -9,8 +9,11 @@ import SimpleAnalytics from "simple-analytics-vue";
  * @param context.isClient
  * @param context.isServer
  */
-export default function (Vue) {
+export default function (Vue, options) {
   if (process.isClient) {
-    Vue.use(SimpleAnalytics, { skip: process.env.NODE_ENV !== 'production' });
+    Vue.use(SimpleAnalytics, { 
+      skip: process.env.NODE_ENV !== 'production',
+      domain: options.domain
+    });
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.1.0",
   "name": "gridsome-plugin-simple-analytics",
   "description": "Simple Analytics plugin for Gridsome",
   "homepage": "https://github.com/simpleanalytics/gridsome-plugin#readme",
@@ -24,7 +24,7 @@
     "access": "public"
   },
   "dependencies": {
-    "simple-analytics-vue": "^1.0.5"
+    "simple-analytics-vue": "^1.1.0"
   },
   "engines": {
     "node": ">=8"


### PR DESCRIPTION
This is an extension for gridsome plugin to support bypassing ad blockers with a optional custom domain.

### Before merging and releasing

1. Please merge https://github.com/simpleanalytics/vue-plugin/pull/1
2. Please release this new NPM package version as `1.1.0`

### What this PR does

1. Adds support for custom domain option
2. Submits option to Vue plugin
3. Bumps up the version of the Vue plugin that is used
4. Bumps up the existing gridsome plugin version since this expands functionality